### PR TITLE
V03: add missing global.h and add cppcheck inline suppression comment.

### DIFF
--- a/command/win32/localtime_r.cpp
+++ b/command/win32/localtime_r.cpp
@@ -3,6 +3,7 @@
 #if __cplusplus <= CPLUSPLUS_20
 #include <time.h>
 #include <errno.h>
+#include "../global.h"
 
 #if defined (WINDOWS)
 struct tm* localtime_r(const time_t* timer, struct tm* buf) {

--- a/command/win32/localtime_r.cpp
+++ b/command/win32/localtime_r.cpp
@@ -14,7 +14,7 @@ struct tm* localtime_r(const time_t* timer, struct tm* buf) {
    * C++11:  struct tm* localtime_s(const time_t* restrict timer, struct tm* restrict buf);
    */
 
-  errno_t r = localtime_s(buf, timer);
+  errno_t r = localtime_s(buf, timer); // cppcheck-suppress AssignmentAddressToInteger
 
   if (r != 0)
      errno = EINVAL;


### PR DESCRIPTION
cppcheck manual, page 17:

Suppressions can also be added directly in the code by adding comments that
contain special keywords.

To activate inline suppressions:

cppcheck --inline-suppr <FILE>